### PR TITLE
Update migration.stub

### DIFF
--- a/src/Console/stubs/migration.stub
+++ b/src/Console/stubs/migration.stub
@@ -15,7 +15,7 @@ class CreateSettingsTable extends Migration
     {
         Schema::create('{table}', function (Blueprint $table) {
             $table->string('key');
-            $table->string('value');
+            $table->text('value')->nullable();
         });
     }
 


### PR DESCRIPTION
Would actually make the value field a text field to accept longer characters, and make it nullable allowed as well. (Since the newer laravel versions null empty strings automatically in `App\Http\Middleware\TrimStrings`)