### PR TITLE
Add ability to use custom db connection

### DIFF
--- a/src/SettingsManager.php
+++ b/src/SettingsManager.php
@@ -2,6 +2,7 @@
 
 namespace Smartisan\Settings;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Manager;
 use Smartisan\Settings\Repositories\JsonRepository;
 use Smartisan\Settings\Repositories\DatabaseRepository;
@@ -38,8 +39,9 @@ class SettingsManager extends Manager
     public function createDatabaseDriver()
     {
         $config = $this->config('drivers.database');
+        $connection = isset($config['connection']) ? DB::connection($config['connection']) : $this->app['db'];
 
-        return new DatabaseRepository($this->app['db'], $config['table']);
+        return new DatabaseRepository($connection, $config['table']);
     }
 
     /**


### PR DESCRIPTION
Hey, Mohammed!
This is actually my first open-source PR, so please don't be too harsh. 

The thing is, we decided to push settings to a separate DB in our project. I created a custom driver for that, but I thought it would be cool if you could specify connection in addition to table. 

Like:

```
 'database' => [
            'table' => 'settings',
            'connection' => 'second_db'
  ],
```

Thanks